### PR TITLE
Add `CalculateDimensions` function to `ModelVariable` to automatically calculate the dimensions on instantiation

### DIFF
--- a/src/GSMP.ModelManager/ModelVariable.cs
+++ b/src/GSMP.ModelManager/ModelVariable.cs
@@ -1,4 +1,6 @@
-﻿namespace GSMP.ModelManager;
+﻿using System.Collections;
+
+namespace GSMP.ModelManager;
 
 public class ModelVariable<T>
 {
@@ -8,14 +10,12 @@ public class ModelVariable<T>
     public T CurrentValue { get; set; }
     public Type Type { get; }
     public string Description { get; }
-    public IReadOnlyList<int> Dimensions { get; }
+    public IReadOnlyList<int>? Dimensions { get; }
 
-    public ModelVariable(string name, VariableIntent intent, T defaultValue,
-                         IReadOnlyList<int> dimensions, string description = "")
+    public ModelVariable(string name, VariableIntent intent, T defaultValue, string description = "")
     {
         ValidateName(name);
         ValidateIntent(intent);
-        ValidateDimensions(dimensions);
 
         Name = name;
         Intent = intent;
@@ -23,9 +23,7 @@ public class ModelVariable<T>
         CurrentValue = defaultValue;
         Type = typeof(T);
         Description = description;
-        Dimensions = dimensions;
-
-        ValidateDimensions();
+        Dimensions = CalculateDimensions(defaultValue);
     }
 
     private static void ValidateName(string name)
@@ -40,30 +38,15 @@ public class ModelVariable<T>
             throw new ArgumentException("Invalid VariableIntent value.", nameof(intent));
     }
 
-    private static void ValidateDimensions(IReadOnlyList<int> dimensions)
+    private static IReadOnlyList<int>? CalculateDimensions(T value)
     {
-        if (dimensions == null || dimensions.Count == 0)
-            throw new ArgumentException("Dimensions cannot be null or empty.", nameof(dimensions));
-
-        if (dimensions.Any(d => d <= 0))
-            throw new ArgumentException("All dimensions must be positive integers.", nameof(dimensions));
-    }
-
-    private void ValidateDimensions()
-    {
-        if (DefaultValue is Array array)
+        return value switch
         {
-            int[] actualDimensions = Enumerable.Range(0, array.Rank)
-                                               .Select(array.GetLength)
-                                               .ToArray();
-
-            if (!actualDimensions.SequenceEqual(Dimensions))
-                throw new ArgumentException("DefaultValue dimensions do not match specified Dimensions.");
-        }
-        else if (Dimensions.Count > 1 || Dimensions[0] != 1)
-        {
-            throw new ArgumentException("Non-array DefaultValue must have Dimensions [1] (a scalar).");
-        }
+            Array { Rank: > 1 } array => Enumerable.Range(0, array.Rank).Select(array.GetLength).ToArray(),
+            Array array => [array.Length],
+            IList list => [list.Count],
+            _ => null
+        };
     }
 
     public void ResetToDefault() => CurrentValue = DefaultValue;

--- a/test/GSMP.ModelManager.Tests/GSMP.ModelManager.Tests/ModelVariableTests.cs
+++ b/test/GSMP.ModelManager.Tests/GSMP.ModelManager.Tests/ModelVariableTests.cs
@@ -6,68 +6,99 @@ public class ModelVariableTests
     [Test]
     public void Constructor_ValidInput_CreatesInstance()
     {
-        var variable = new ModelVariable<int>("TestVar", VariableIntent.Input, -1, new[] { 1 }, "Test description");
+        var variable = new ModelVariable<int>("TestVar", VariableIntent.Input, -1, "Test description");
 
-        Assert.That(variable.Name, Is.EqualTo("TestVar"));
-        Assert.That(variable.Intent, Is.EqualTo(VariableIntent.Input));
-        Assert.That(variable.DefaultValue, Is.EqualTo(-1));
-        Assert.That(variable.CurrentValue, Is.EqualTo(-1));
-        Assert.That(variable.Type, Is.EqualTo(typeof(int)));
-        Assert.That(variable.Description, Is.EqualTo("Test description"));
-        Assert.That(variable.Dimensions, Is.EqualTo(new[] { 1 }));
+        Assert.Multiple(() =>
+        {
+            Assert.That(variable.Name, Is.EqualTo("TestVar"));
+            Assert.That(variable.Intent, Is.EqualTo(VariableIntent.Input));
+            Assert.That(variable.DefaultValue, Is.EqualTo(-1));
+            Assert.That(variable.CurrentValue, Is.EqualTo(-1));
+            Assert.That(variable.Type, Is.EqualTo(typeof(int)));
+            Assert.That(variable.Description, Is.EqualTo("Test description"));
+            Assert.That(variable.Dimensions, Is.EqualTo(null));
+        });
     }
 
     [Test]
     public void Constructor_EmptyName_ThrowsArgumentException()
     {
-        Assert.Throws<ArgumentException>(() => new ModelVariable<int>("", VariableIntent.Input, 0, new[] { 1 }));
+        Assert.Throws<ArgumentException>(() => new ModelVariable<int>("", VariableIntent.Input, 0));
     }
 
     [Test]
     public void Constructor_InvalidIntent_ThrowsArgumentException()
     {
-        Assert.Throws<ArgumentException>(() => new ModelVariable<int>("TestVar", (VariableIntent)999, 0, new[] { 1 }));
+        Assert.Throws<ArgumentException>(() => new ModelVariable<int>("TestVar", (VariableIntent)999, 0));
     }
 
     [Test]
-    public void Constructor_EmptyDimensions_ThrowsArgumentException()
+    public void Constructor_ScalarValue_DimensionsAreNull()
     {
-        Assert.Throws<ArgumentException>(() =>
-            new ModelVariable<int>("TestVar", VariableIntent.Input, 0, Array.Empty<int>()));
+        var variable = new ModelVariable<int>("ScalarInt", VariableIntent.Input, 42);
+        Assert.IsNull(variable.Dimensions);
     }
 
     [Test]
-    public void Constructor_NegativeDimension_ThrowsArgumentException()
+    public void Constructor_SingleDimensionArray_ReturnsCorrectDimensions()
     {
-        Assert.Throws<ArgumentException>(() =>
-            new ModelVariable<int>("TestVar", VariableIntent.Input, 0, new[] { -1 }));
+        int[] array = [1, 2, 3, 4, 5, 6];
+        var variable = new ModelVariable<int[]>("OneDArray", VariableIntent.Input, array);
+        Assert.That(variable.Dimensions, Is.EquivalentTo(new[] { 6 }));
     }
 
     [Test]
-    public void Constructor_ArrayDefaultValue_MatchingDimensions_CreatesInstance()
+    public void Constructor_TwoDimensionArray_ReturnsCorrectDimensions()
     {
-        var variable = new ModelVariable<int[,]>("TestVar", VariableIntent.Input, new int[2, 3], new[] { 2, 3 });
-        Assert.That(variable.Dimensions, Is.EqualTo(new[] { 2, 3 }));
+        int[,] array = { { 1, 2, 3 }, { 4, 5, 6 } };
+        var variable = new ModelVariable<int[,]>("TwoDArray", VariableIntent.Input, array);
+        Assert.That(variable.Dimensions, Is.EquivalentTo(new[] { 2, 3 }));
     }
 
     [Test]
-    public void Constructor_ArrayDefaultValue_MismatchedDimensions_ThrowsArgumentException()
+    public void Constructor_JaggedArray_ReturnsToplevelDimension()
     {
-        Assert.Throws<ArgumentException>(() =>
-            new ModelVariable<int[,]>("TestVar", VariableIntent.Input, new int[2, 3], new[] { 3, 2 }));
+        int[][] jaggedArray = [[1, 2, 3], [4, 5, 6, 7]];
+        var variable = new ModelVariable<int[][]>("JaggedArray", VariableIntent.Input, jaggedArray);
+        Assert.That(variable.Dimensions, Is.EquivalentTo(new[] { 2 }));
     }
 
     [Test]
-    public void Constructor_NonArrayDefaultValue_NonScalarDimensions_ThrowsArgumentException()
+    public void Constructor_List_ReturnsCorrectDimension()
     {
-        Assert.Throws<ArgumentException>(() =>
-            new ModelVariable<int>("TestVar", VariableIntent.Input, 0, new[] { 2, 3 }));
+        var list = new List<string> { "a", "b", "c", "d" };
+        var variable = new ModelVariable<List<string>>("StringList", VariableIntent.Input, list);
+        Assert.That(variable.Dimensions, Is.EquivalentTo(new[] { 4 }));
+    }
+
+    [Test]
+    public void Constructor_EmptyArray_ReturnsZeroDimension()
+    {
+        int[] emptyArray = [];
+        var variable = new ModelVariable<int[]>("EmptyArray", VariableIntent.Input, emptyArray);
+        Assert.That(variable.Dimensions, Is.EquivalentTo(new[] { 0 }));
+    }
+
+    [Test]
+    public void Constructor_EmptyList_ReturnsZeroDimension()
+    {
+        var emptyList = new List<double>();
+        var variable = new ModelVariable<List<double>>("EmptyList", VariableIntent.Input, emptyList);
+        Assert.That(variable.Dimensions, Is.EquivalentTo(new[] { 0 }));
+    }
+
+    [Test]
+    public void Constructor_ThreeDimensionArray_ReturnsCorrectDimensions()
+    {
+        int[,,] array = new int[2, 3, 4];
+        var variable = new ModelVariable<int[,,]>("ThreeDArray", VariableIntent.Input, array);
+        Assert.That(variable.Dimensions, Is.EquivalentTo(new[] { 2, 3, 4 }));
     }
 
     [Test]
     public void ResetToDefault_SetsCurrentValueToDefaultValue()
     {
-        var variable = new ModelVariable<int>("TestVar", VariableIntent.Input, 0, new[] { 1 }) { CurrentValue = 5 };
+        var variable = new ModelVariable<int>("TestVar", VariableIntent.Input, 0) { CurrentValue = 5 };
         variable.ResetToDefault();
         Assert.That(variable.CurrentValue, Is.EqualTo(variable.DefaultValue));
     }
@@ -75,14 +106,14 @@ public class ModelVariableTests
     [Test]
     public void ToString_ReturnsExpectedString()
     {
-        var variable = new ModelVariable<int>("TestVar", VariableIntent.Input, 0, new[] { 1 });
+        var variable = new ModelVariable<int>("TestVar", VariableIntent.Input, 0);
         Assert.That(variable.ToString(), Is.EqualTo("TestVar (Input): 0 (Default: 0)"));
     }
 
     [Test]
     public void CurrentValue_CanBeSet()
     {
-        var variable = new ModelVariable<int>("TestVar", VariableIntent.Input, 0, new[] { 1 }) { CurrentValue = 5 };
+        var variable = new ModelVariable<int>("TestVar", VariableIntent.Input, 0) { CurrentValue = 5 };
         Assert.That(variable.CurrentValue, Is.EqualTo(5));
     }
 }


### PR DESCRIPTION
Adds a new method to `ModelVariable` that calculates the dimensions of `DefaultValue` automatically.

This ensures that the `Dimensions` variable is always the same as the actual dimensions of `DefaultValue`.