### PR TITLE
Add basic CLI executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ include(FetchContent)
 add_subdirectory(src/models/C)
 add_subdirectory(src/models/CPP)
 
+# Executable code
+add_subdirectory(src/cli)
+
 # Testing only available if this is the main app
 # Emergency override MODERN_CMAKE_BUILD_TESTING provided as well
 #if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR MODERN_CMAKE_BUILD_TESTING)

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(GSMP cli.cpp)
+target_compile_features(GSMP PRIVATE cxx_std_17)
+
+target_link_libraries(GSMP PRIVATE GSMP_CPP GSMP_C)

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+
+int main()
+{
+    std::cout << "Hello, world!";
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This adds a basic executable to the GSMP project that is intended to be used as the CLI in the future.