### PR TITLE
Allow `update_variable` method to take template parameter.

### DIFF
--- a/src/gsmp/include/model_variable.h
+++ b/src/gsmp/include/model_variable.h
@@ -20,7 +20,8 @@ public:
     template<typename T>
     T get_value() const;
 
-    void set_value(const GSMPType &new_value);
+    template<typename T>
+    void set_value(T new_value);
 
     [[nodiscard]] std::string get_type_string() const;
 

--- a/src/gsmp/include/variable_manager.h
+++ b/src/gsmp/include/variable_manager.h
@@ -14,7 +14,8 @@ public:
 
     ModelVariable get_variable(const std::string &name) const;
 
-    void update_variable(const std::string &name, const GSMPType &value);
+    template<typename T>
+    void update_variable(const std::string &name, T value);
 
     void clear();
 

--- a/src/gsmp/src/model_variable.cpp
+++ b/src/gsmp/src/model_variable.cpp
@@ -1,7 +1,15 @@
 #include "model_variable.h"
+#include <format>
 #include <stdexcept>
 
-void ModelVariable::set_value(const GSMPType &new_value)
+template<typename T>
+T ModelVariable::get_value() const
+{
+    return _value;
+}
+
+template<typename T>
+void ModelVariable::set_value(const T new_value)
 {
     // Ensures new value matches the current type
     std::visit(
@@ -10,7 +18,7 @@ void ModelVariable::set_value(const GSMPType &new_value)
                 using NewType = std::decay_t<decltype(val)>;
                 if (!std::holds_alternative<NewType>(_value))
                 {
-                    throw std::runtime_error("Type mismatch in set_value");
+                    throw std::runtime_error(std::format("Value {} is not a supported GSMP type", val));
                 }
                 _value = val;
             },

--- a/src/gsmp/src/variable_manager.cpp
+++ b/src/gsmp/src/variable_manager.cpp
@@ -34,7 +34,8 @@ ModelVariable VariableManager::get_variable(const std::string &name) const
     }
 }
 
-void VariableManager::update_variable(const std::string &name, const GSMPType &value)
+template<typename T>
+void VariableManager::update_variable(const std::string &name, const T value)
 {
     try
     {


### PR DESCRIPTION
This change now allows `set_value` to take a template parameter T, rather than a raw GSMPType value. This ensures compatibility with a C API.