### PR TITLE
[C API] VariableManager Prototype

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,8 @@
   "plantuml.includepaths": [
     "docs/PlantUML/diagrams/style",
     "docs/PlantUML/diagrams/src"
+  ],
+  "cSpell.words": [
+    "GSMP"
   ]
 }

--- a/src/models/c/include/GSMP_Model_API.h
+++ b/src/models/c/include/GSMP_Model_API.h
@@ -1,0 +1,83 @@
+﻿/* ────────────────────────────────────────────────────────────────── *
+* FILENAME : GSMP_Model_API.h
+*
+* DESCRIPTION : Declares external functions to implement the C API to
+*               CPP Class 'Model'.
+*
+/* ────────────────────────────────────────────────────────────────── */
+
+#ifndef GSMP_MODEL_API_H
+#define GSMP_MODEL_API_H
+
+/* ┌────────────────────────────────────────────────────────────────┐ */
+/* │                            LINKAGE                             │ */
+/* └────────────────────────────────────────────────────────────────┘ */
+
+#if defined(__cplusplus)
+#define GSMP_LINKAGE extern 'C'
+#else
+#define GSMP_LINKAGE extern
+#endif
+
+/* ┌────────────────────────────────────────────────────────────────┐ */
+/* │                          VISIBILITY                            │ */
+/* └────────────────────────────────────────────────────────────────┘ */
+
+#if defined(_MSC_VER) && defined(GSMP_BUILD_SHARED)
+// Build as Windows Shared Library (.dll)
+#define GSMP_API GSMP_LINKAGE __declspec(dllexport)
+#elif defined(_MSC_VER) && defined(GSMP_USE_SHARED)
+// Use as a Windows Shared Library (.dll)
+#define GSMP_API GSMP_LINKAGE __declspec(dllimport)
+#elif defined(_MSC_VER) && defined(GSMP_BUILD_SHARED)
+// Build as Unix Shared Library (.so)
+#define GSMP_API GSMP_LINKAGE __attribute__((visibility("default")))
+#else
+// Visibility Unmodified, for Static Linkage (.lib)
+#define GSMP_API GSMP_LINKAGE
+#endif
+
+/* ┌────────────────────────────────────────────────────────────────┐ */
+/* │                           GSMP MODEL                           │ */
+/* └────────────────────────────────────────────────────────────────┘ */
+
+#include "GSMP_model_types.h"
+
+// Opaque pointer to GSMP Model Instance
+typedef struct GSMP_Instance GSMP_Instance;
+
+// Model Instance Management
+GSMP_API int GSMP_Model_Create(GSMP_Instance *instance);
+
+GSMP_API int GSMP_Model_Destroy(GSMP_Instance *instance);
+
+// Model Runtime
+GSMP_API int GSMP_Model_Initialize(GSMP_Instance *instance);
+
+GSMP_API int GSMP_Model_Reinitialize(GSMP_Instance *instance);
+
+GSMP_API int GSMP_Model_Step(GSMP_Instance *instance);
+
+GSMP_API int GSMP_Model_Terminate(GSMP_Instance *instance);
+
+// Model Variables
+GSMP_API int GSMP_Model_GetVariableType(GSMP_Instance *instance, char *name, int *value);
+
+GSMP_API int GSMP_Model_GetVariableDescription(GSMP_Instance *instance, char *name, int *value);
+
+GSMP_API int GSMP_Model_SetVariable_Int(GSMP_Instance *instance, char *name, int *value);
+
+GSMP_API int GSMP_Model_SetVariable_Float(GSMP_Instance *instance, char *name, float *value);
+
+GSMP_API int GSMP_Model_SetVariable_Double(GSMP_Instance *instance, char *name, double *value);
+
+GSMP_API int GSMP_Model_GetVariable_Int(GSMP_Instance *instance, char *name, int *value);
+
+GSMP_API int GSMP_Model_GetVariable_Float(GSMP_Instance *instance, char *name, float *value);
+
+GSMP_API int GSMP_Model_GetVariable_Double(GSMP_Instance *instance, char *name, double *value);
+
+// ... TODO: GSMP Supported Types //
+// ... TODO: GSMP Supported Arrays //
+
+#endif // GSMP_MODEL_API_H

--- a/src/models/c/include/GSMP_Model_API.h
+++ b/src/models/c/include/GSMP_Model_API.h
@@ -41,7 +41,8 @@
 /* │                           GSMP MODEL                           │ */
 /* └────────────────────────────────────────────────────────────────┘ */
 
-#include "GSMP_model_types.h"
+#include "GSMP_enums.h"
+#include "GSMP_types.h"
 
 // Opaque pointer to GSMP Model Instance
 typedef struct GSMP_Instance GSMP_Instance;

--- a/src/models/c/include/GSMP_VariableManager_API.h
+++ b/src/models/c/include/GSMP_VariableManager_API.h
@@ -1,13 +1,13 @@
-﻿/* ────────────────────────────────────────────────────────────────── *
-* FILENAME : GSMP_model.h
+/* ────────────────────────────────────────────────────────────────── *
+* FILENAME : GSMP_VariableManager_API.h
 *
-* DESCRIPTION : Declares external functions to implement the Model
-*               Interface.
+* DESCRIPTION : Declares external functions to implement the C API to
+*               CPP Class 'Model'.
 *
 /* ────────────────────────────────────────────────────────────────── */
 
-#ifndef GSMP_MODEL_H
-#define	GSMP_MODEL_H
+#ifndef GSMP_VARIABLE_MANAGER_API_H
+#define GSMP_VARIABLE_MANAGER_API_H
 
 /* ┌────────────────────────────────────────────────────────────────┐ */
 /* │                            LINKAGE                             │ */
@@ -31,7 +31,7 @@
 #define GSMP_API GSMP_LINKAGE __declspec(dllimport)
 #elif defined(_MSC_VER) && defined(GSMP_BUILD_SHARED)
 // Build as Unix Shared Library (.so)
-#define GSMP_API GSMP_LINKAGE __attribute__((visbility("default")))
+#define GSMP_API GSMP_LINKAGE __attribute__((visibility("default")))
 #else
 // Visibility Unmodified, for Static Linkage (.lib)
 #define GSMP_API GSMP_LINKAGE
@@ -43,42 +43,35 @@
 
 #include "GSMP_model_types.h"
 
-// Opaque pointer to GSMP Model Instance
-typedef struct GSMPModel GSMPModel;
+// Opaque pointer to GSMP Variable Manager Instance
+typedef struct GSMP_Instance GSMP_Instance;
 
 // Model Instance Management
-GSMP_API int GSMP_Model_Create(GSMPModel *model);
+GSMP_API int GSMP_Variable_Manager_Create(GSMP_Instance *instance);
 
-GSMP_API int GSMP_Model_Destroy(GSMPModel *model);
+GSMP_API int GSMP_Variable_Manager_Destroy(GSMP_Instance *instance);
 
-// Model Runtime
-GSMP_API int GSMP_Model_Initialize(GSMPModel *model);
+// Model Variable Instantiation
 
-GSMP_API int GSMP_Model_Reinitialize(GSMPModel *model);
 
-GSMP_API int GSMP_Model_Step(GSMPModel *model);
+// Model Variables (Runtime)
+GSMP_API int GSMP_Variable_Manager_GetVariableType(GSMP_Instance *instance, char *name, int *value);
 
-GSMP_API int GSMP_Model_Terminate(GSMPModel *model);
+GSMP_API int GSMP_Variable_Manager_GetVariableDescription(GSMP_Instance *instance, char *name, int *value);
 
-// Model Variables
-GSMP_API int GSMP_Model_GetVariableType(GSMPModel *model, char *name, int *value);
+GSMP_API int GSMP_Variable_Manager_SetVariable_Int(GSMP_Instance *instance, char *name, int *value);
 
-GSMP_API int GSMP_Model_GetVariableDescription(GSMPModel *model, char *name, int *value);
+GSMP_API int GSMP_Variable_Manager_SetVariable_Float(GSMP_Instance *instance, char *name, float *value);
 
-GSMP_API int GSMP_Model_SetVariable_Int(GSMPModel *model, char *name, int *value);
+GSMP_API int GSMP_Variable_Manager_SetVariable_Double(GSMP_Instance *instance, char *name, double *value);
 
-GSMP_API int GSMP_Model_SetVariable_Float(GSMPModel *model, char *name, float *value);
+GSMP_API int GSMP_Variable_Manager_GetVariable_Int(GSMP_Instance *instance, char *name, int *value);
 
-GSMP_API int GSMP_Model_SetVariable_Double(GSMPModel *model, char *name, double *value);
+GSMP_API int GSMP_Variable_Manager_GetVariable_Float(GSMP_Instance *instance, char *name, float *value);
 
-GSMP_API int GSMP_Model_GetVariable_Int(GSMPModel *model, char *name, int *value);
-
-GSMP_API int GSMP_Model_GetVariable_Float(GSMPModel *model, char *name, float *value);
-
-GSMP_API int GSMP_Model_GetVariable_Double(GSMPModel *model, char *name, double *value);
+GSMP_API int GSMP_Variable_Manager_GetVariable_Double(GSMP_Instance *instance, char *name, double *value);
 
 // ... TODO: GSMP Supported Types //
 // ... TODO: GSMP Supported Arrays //
 
-#endif // GSMP_MODEL_H
-
+#endif // GSMP_VARIABLE_MANAGER_API_H

--- a/src/models/c/include/GSMP_VariableManager_API.h
+++ b/src/models/c/include/GSMP_VariableManager_API.h
@@ -2,7 +2,7 @@
 * FILENAME : GSMP_VariableManager_API.h
 *
 * DESCRIPTION : Declares external functions to implement the C API to
-*               CPP Class 'Model'.
+*               CPP Class 'VariableManager'.
 *
 /* ────────────────────────────────────────────────────────────────── */
 
@@ -25,53 +25,60 @@
 
 #if defined(_MSC_VER) && defined(GSMP_BUILD_SHARED)
 // Build as Windows Shared Library (.dll)
-#define GSMP_API GSMP_LINKAGE __declspec(dllexport)
+#define GSMP_VISIBILITY GSMP_LINKAGE __declspec(dllexport)
 #elif defined(_MSC_VER) && defined(GSMP_USE_SHARED)
 // Use as a Windows Shared Library (.dll)
-#define GSMP_API GSMP_LINKAGE __declspec(dllimport)
+#define GSMP_VISIBILITY GSMP_LINKAGE __declspec(dllimport)
 #elif defined(_MSC_VER) && defined(GSMP_BUILD_SHARED)
 // Build as Unix Shared Library (.so)
-#define GSMP_API GSMP_LINKAGE __attribute__((visibility("default")))
+#define GSMP_VISIBILITY GSMP_LINKAGE __attribute__((visibility("default")))
 #else
 // Visibility Unmodified, for Static Linkage (.lib)
-#define GSMP_API GSMP_LINKAGE
+#define GSMP_VISIBILITY GSMP_LINKAGE
 #endif
 
 /* ┌────────────────────────────────────────────────────────────────┐ */
-/* │                           GSMP MODEL                           │ */
+/* │                           RETURN CODE                          │ */
 /* └────────────────────────────────────────────────────────────────┘ */
 
-#include "GSMP_model_types.h"
+#define GSMP_API GSMP_VISIBILITY ReturnCode
+
+/* ┌────────────────────────────────────────────────────────────────┐ */
+/* │                      GSMP VARIABLE MANAGER                     │ */
+/* └────────────────────────────────────────────────────────────────┘ */
+
+#include "GSMP_enums.h"
+#include "GSMP_types.h"
 
 // Opaque pointer to GSMP Variable Manager Instance
 typedef struct GSMP_Instance GSMP_Instance;
 
 // Model Instance Management
-GSMP_API int GSMP_Variable_Manager_Create(GSMP_Instance *instance);
+GSMP_API GSMP_VariableManager_Create(GSMP_Instance *instance);
 
-GSMP_API int GSMP_Variable_Manager_Destroy(GSMP_Instance *instance);
+GSMP_API GSMP_VariableManager_Destroy(GSMP_Instance *instance);
 
 // Model Variable Instantiation
-
+GSMP_API GSMP_VariableManager_AddVariable_Int(GSMP_Instance *instance, const string_t name, int_t *value,
+                                              VariableIntent *variableIntent, string_t description);
+GSMP_API GSMP_VariableManager_AddVariable_Single(GSMP_Instance *instance, string_t name, int_t *value,
+                                                 VariableIntent *intent, string_t description);
+GSMP_API GSMP_VariableManager_AddVariable_Double(GSMP_Instance *instance, string_t name, int_t *value,
+                                                 VariableIntent *intent, string_t description);
 
 // Model Variables (Runtime)
-GSMP_API int GSMP_Variable_Manager_GetVariableType(GSMP_Instance *instance, char *name, int *value);
+GSMP_API GSMP_VariableManager_GetVariableType(GSMP_Instance *instance, string_t name, int_t *value);
 
-GSMP_API int GSMP_Variable_Manager_GetVariableDescription(GSMP_Instance *instance, char *name, int *value);
+GSMP_API GSMP_VariableManager_GetVariableIntent(GSMP_Instance *instance, string_t name, VariableIntent *variableIntent);
 
-GSMP_API int GSMP_Variable_Manager_SetVariable_Int(GSMP_Instance *instance, char *name, int *value);
+GSMP_API GSMP_VariableManager_GetVariableDescription(GSMP_Instance *instance, string_t name, int_t *value);
 
-GSMP_API int GSMP_Variable_Manager_SetVariable_Float(GSMP_Instance *instance, char *name, float *value);
+GSMP_API GSMP_VariableManager_SetVariable_Int(GSMP_Instance *instance, string_t name, int_t *value);
+GSMP_API GSMP_VariableManager_SetVariable_Single(GSMP_Instance *instance, string_t name, single_t *value);
+GSMP_API GSMP_VariableManager_SetVariable_Double(GSMP_Instance *instance, string_t name, double_t *value);
 
-GSMP_API int GSMP_Variable_Manager_SetVariable_Double(GSMP_Instance *instance, char *name, double *value);
-
-GSMP_API int GSMP_Variable_Manager_GetVariable_Int(GSMP_Instance *instance, char *name, int *value);
-
-GSMP_API int GSMP_Variable_Manager_GetVariable_Float(GSMP_Instance *instance, char *name, float *value);
-
-GSMP_API int GSMP_Variable_Manager_GetVariable_Double(GSMP_Instance *instance, char *name, double *value);
-
-// ... TODO: GSMP Supported Types //
-// ... TODO: GSMP Supported Arrays //
+GSMP_API GSMP_VariableManager_GetVariable_Int(GSMP_Instance *instance, string_t name, int_t *value);
+GSMP_API GSMP_VariableManager_GetVariable_Single(GSMP_Instance *instance, string_t name, single_t *value);
+GSMP_API GSMP_VariableManager_GetVariable_Double(GSMP_Instance *instance, string_t name, double_t *value);
 
 #endif // GSMP_VARIABLE_MANAGER_API_H

--- a/src/models/c/include/GSMP_VariableManager_API.h
+++ b/src/models/c/include/GSMP_VariableManager_API.h
@@ -59,26 +59,28 @@ GSMP_API GSMP_VariableManager_Create(GSMP_Instance *instance);
 GSMP_API GSMP_VariableManager_Destroy(GSMP_Instance *instance);
 
 // Model Variable Instantiation
-GSMP_API GSMP_VariableManager_AddVariable_Int(GSMP_Instance *instance, const string_t name, int_t *value,
-                                              VariableIntent *variableIntent, string_t description);
-GSMP_API GSMP_VariableManager_AddVariable_Single(GSMP_Instance *instance, string_t name, int_t *value,
-                                                 VariableIntent *intent, string_t description);
-GSMP_API GSMP_VariableManager_AddVariable_Double(GSMP_Instance *instance, string_t name, int_t *value,
-                                                 VariableIntent *intent, string_t description);
+GSMP_API GSMP_VariableManager_AddVariable_Int(GSMP_Instance *instance, const string_t name, const int_t value,
+                                              VariableIntent intent, const string_t description);
+GSMP_API GSMP_VariableManager_AddVariable_Single(GSMP_Instance *instance, const string_t name, const single_t value,
+                                                 VariableIntent intent, const string_t description);
+GSMP_API GSMP_VariableManager_AddVariable_Double(GSMP_Instance *instance, const string_t name, const double_t value,
+                                                 VariableIntent intent, const string_t description);
 
 // Model Variables (Runtime)
-GSMP_API GSMP_VariableManager_GetVariableType(GSMP_Instance *instance, string_t name, int_t *value);
+GSMP_API GSMP_VariableManager_GetVariableType(GSMP_Instance *instance, const string_t name, int_t *pValue);
 
-GSMP_API GSMP_VariableManager_GetVariableIntent(GSMP_Instance *instance, string_t name, VariableIntent *variableIntent);
+GSMP_API GSMP_VariableManager_GetVariableIntent(GSMP_Instance *instance, const string_t name,
+                                                VariableIntent *pVariableIntent);
 
-GSMP_API GSMP_VariableManager_GetVariableDescription(GSMP_Instance *instance, string_t name, int_t *value);
+GSMP_API GSMP_VariableManager_GetVariableDescription(GSMP_Instance *instance, const string_t name,
+                                                     string_t *pDescription);
 
-GSMP_API GSMP_VariableManager_SetVariable_Int(GSMP_Instance *instance, string_t name, int_t *value);
-GSMP_API GSMP_VariableManager_SetVariable_Single(GSMP_Instance *instance, string_t name, single_t *value);
-GSMP_API GSMP_VariableManager_SetVariable_Double(GSMP_Instance *instance, string_t name, double_t *value);
+GSMP_API GSMP_VariableManager_SetVariable_Int(GSMP_Instance *instance, const string_t name, int_t *pValue);
+GSMP_API GSMP_VariableManager_SetVariable_Single(GSMP_Instance *instance, const string_t name, single_t *pValue);
+GSMP_API GSMP_VariableManager_SetVariable_Double(GSMP_Instance *instance, const string_t name, double_t *pValue);
 
-GSMP_API GSMP_VariableManager_GetVariable_Int(GSMP_Instance *instance, string_t name, int_t *value);
-GSMP_API GSMP_VariableManager_GetVariable_Single(GSMP_Instance *instance, string_t name, single_t *value);
-GSMP_API GSMP_VariableManager_GetVariable_Double(GSMP_Instance *instance, string_t name, double_t *value);
+GSMP_API GSMP_VariableManager_GetVariable_Int(GSMP_Instance *instance, const string_t name, int_t *pValue);
+GSMP_API GSMP_VariableManager_GetVariable_Single(GSMP_Instance *instance, const string_t name, single_t *pValue);
+GSMP_API GSMP_VariableManager_GetVariable_Double(GSMP_Instance *instance, const string_t name, double_t *pValue);
 
 #endif // GSMP_VARIABLE_MANAGER_API_H

--- a/src/models/c/include/GSMP_enums.h
+++ b/src/models/c/include/GSMP_enums.h
@@ -1,20 +1,21 @@
 ﻿/* ────────────────────────────────────────────────────────────────── *
-* FILENAME : GSMP_model_types.h
-*
-* DESCRIPTION : Declares all common GSMP Model types.
-*
-/* ────────────────────────────────────────────────────────────────── */
+ * FILENAME : GSMP_model_types.h
+ *
+ * DESCRIPTION : Defines all GSMP Enumerations used by:
+ *               Model, VariableManager, & Variable.
+ *
+ *  ────────────────────────────────────────────────────────────────── */
 
-#ifndef GSMP_MODEL_TYPES_H
-#define GSMP_MODEL_TYPES_H
+#ifndef GSMP_ENUMS_H
+#define GSMP_ENUMS_H
 
 /* ┌────────────────────────────────────────────────────────────────┐ */
 /* │                      GSMP ENUMERATIONS                         │ */
 /* └────────────────────────────────────────────────────────────────┘ */
 
-enum VariableIntent { UNDEFINED, INPUT, OUTPUT, OVERRIDE };
+typedef enum { UNDEFINED, INPUT, OUTPUT, OVERRIDE } VariableIntent;
 
-enum VariableType {
+typedef enum {
     DOUBLE, // double
     SINGLE, // float
     BYTE, // int8_t
@@ -27,8 +28,8 @@ enum VariableType {
     UNSIGNED_LONG, // uint64_t
     BOOLEAN, // bool
     STRING // char*
-};
+} VariableType;
 
-enum ReturnCode { OK = 0, ERROR = -1, PENDING = 1 };
+typedef enum { OK = 0, ERROR = -1, PENDING = 1 } ReturnCode;
 
-#endif // GSMP_MODEL_TYPES_H
+#endif // GSMP_ENUMS_H

--- a/src/models/c/include/GSMP_enums.h
+++ b/src/models/c/include/GSMP_enums.h
@@ -1,5 +1,5 @@
 ﻿/* ────────────────────────────────────────────────────────────────── *
- * FILENAME : GSMP_model_types.h
+ * FILENAME : GSMP_enums.h
  *
  * DESCRIPTION : Defines all GSMP Enumerations used by:
  *               Model, VariableManager, & Variable.

--- a/src/models/c/include/GSMP_model_types.h
+++ b/src/models/c/include/GSMP_model_types.h
@@ -6,36 +6,29 @@
 /* ────────────────────────────────────────────────────────────────── */
 
 #ifndef GSMP_MODEL_TYPES_H
-#define	GSMP_MODEL_TYPES_H
+#define GSMP_MODEL_TYPES_H
 
 /* ┌────────────────────────────────────────────────────────────────┐ */
-/* │                      GSMP MODEL ENUMERATIONS                   │ */
+/* │                      GSMP ENUMERATIONS                         │ */
 /* └────────────────────────────────────────────────────────────────┘ */
 
-enum ModelVariableType {
-    GSMP_Int = 1,
-    GSMP_Float = 2,
-    GSMP_Double = 3
+enum VariableIntent { UNDEFINED, INPUT, OUTPUT, OVERRIDE };
+
+enum VariableType {
+    DOUBLE, // double
+    SINGLE, // float
+    BYTE, // int8_t
+    UNSIGNED_BYTE, // uint8_t
+    SHORT, // int16_t
+    UNSIGNED_SHORT, // uint16_t
+    INT, // int32_t
+    UNSIGNED_INT, // uint32_t
+    LONG, // int64_t
+    UNSIGNED_LONG, // uint64_t
+    BOOLEAN, // bool
+    STRING // char*
 };
 
-// TODO: Implement Return Codes
-enum GSMP_Return {
-    GSMP_OK = 0,
-    GSMP_ERROR = -1,
-    GSMP_PENDING = 1
-};
-
-/* ┌────────────────────────────────────────────────────────────────┐ */
-/* │                     GSMP MODEL VARIABLE TYPES                  │ */
-/* └────────────────────────────────────────────────────────────────┘ */
-
-typedef struct ModelVariable {
-    char *name;
-    enum ModelVariableType type;
-    char *description;
-    void *pValue;
-} GSMP_Variable_t;
-
-// TODO: Switch to type specific versions vs generic.
+enum ReturnCode { OK = 0, ERROR = -1, PENDING = 1 };
 
 #endif // GSMP_MODEL_TYPES_H

--- a/src/models/c/include/GSMP_types.h
+++ b/src/models/c/include/GSMP_types.h
@@ -1,0 +1,35 @@
+/* ────────────────────────────────────────────────────────────────── *
+ * FILENAME : GSMP_types.h
+ *
+ * DESCRIPTION : Defines all GSMP Types used by:
+ *               Model, VariableManager, & Variable.
+ *
+ *  ────────────────────────────────────────────────────────────────── */
+
+#ifndef GSMP_TYPES_H
+#define GSMP_TYPES_H
+
+/* ┌────────────────────────────────────────────────────────────────┐ */
+/* │                         GSMP TYPES                             │ */
+/* └────────────────────────────────────────────────────────────────┘ */
+
+#include <stdint.h>
+
+// QUESTION: Use alias name style that is common to all our types that are enumerated?
+typedef double double_t;
+typedef float single_t;
+typedef int8_t byte_t;
+typedef uint8_t unsigned_byte_t;
+typedef int16_t short_t;
+typedef uint16_t unsigned_short_t;
+typedef int32_t int_t;
+typedef uint32_t unsigned_int_t;
+typedef int64_t long_t;
+typedef uint64_t unsigned_long_t;
+typedef bool boolean_t;
+typedef char *string_t;
+
+// NULL for C, or use <stdlib. h>. For Cpp use nullptr.
+#define NULL ((void *) 0)
+
+#endif // GSMP_TYPES_H

--- a/src/models/c/src/GSMP_Model_API.cpp
+++ b/src/models/c/src/GSMP_Model_API.cpp
@@ -16,22 +16,19 @@
 // TODO: How to reference into this style of structure. For example
 //       to find name 'iInt'. Might have to consider an alternative
 //       that's an array.
-typedef struct GSMP_Inputs
-{
+typedef struct GSMP_Inputs {
     GSMP_Variable_t iInt;
     GSMP_Variable_t iFloat;
     GSMP_Variable_t iDouble;
 } GSMPInputs_t;
 
-typedef struct GSMPOutputs
-{
+typedef struct GSMPOutputs {
     GSMP_Variable_t oInt;
     GSMP_Variable_t oFloat;
     GSMP_Variable_t oDouble;
 } GSMPOutputs_t;
 
-typedef struct GSMPModel
-{
+typedef struct GSMPModel {
     double time;
     double timeStep;
 
@@ -63,10 +60,7 @@ GSMP_API int GSMP_Model_Destroy(GSMPModel *model)
 // Model Runtime
 /* ────────────────────────────────────────────────────────────────── */
 
-GSMP_API int GSMP_Model_Initialize(GSMPModel *model)
-{
-    return 0;
-}
+GSMP_API int GSMP_Model_Initialize(GSMPModel *model) { return 0; }
 
 GSMP_API int GSMP_Model_Reinitialize(GSMPModel *model)
 {
@@ -107,32 +101,14 @@ GSMP_API int GSMP_Model_GetVariableDescription(GSMPModel *model, char *name, int
     return 0;
 }
 
-GSMP_API int GSMP_Model_SetVariable_Int(GSMPModel *model, char *name, int *value)
-{
-    return 0;
-}
+GSMP_API int GSMP_Model_SetVariable_Int(GSMPModel *model, char *name, int *value) { return 0; }
 
-GSMP_API int GSMP_Model_SetVariable_Float(GSMPModel *model, char *name, float *value)
-{
-    return 0;
-}
+GSMP_API int GSMP_Model_SetVariable_Float(GSMPModel *model, char *name, float *value) { return 0; }
 
-GSMP_API int GSMP_Model_SetVariable_Double(GSMPModel *model, char *name, double *value)
-{
-    return 0;
-}
+GSMP_API int GSMP_Model_SetVariable_Double(GSMPModel *model, char *name, double *value) { return 0; }
 
-GSMP_API int GSMP_Model_GetVariable_Int(GSMPModel *model, char *name, int *value)
-{
-    return 0;
-}
+GSMP_API int GSMP_Model_GetVariable_Int(GSMPModel *model, char *name, int *value) { return 0; }
 
-GSMP_API int GSMP_Model_GetVariable_Float(GSMPModel *model, char *name, float *value)
-{
-    return 0;
-}
+GSMP_API int GSMP_Model_GetVariable_Float(GSMPModel *model, char *name, float *value) { return 0; }
 
-GSMP_API int GSMP_Model_GetVariable_Double(GSMPModel *model, char *name, double *value)
-{
-    return 0;
-}
+GSMP_API int GSMP_Model_GetVariable_Double(GSMPModel *model, char *name, double *value) { return 0; }

--- a/src/models/c/src/GSMP_VariableManager_API.cpp
+++ b/src/models/c/src/GSMP_VariableManager_API.cpp
@@ -18,6 +18,8 @@
 // Model Instance Management
 GSMP_API GSMP_VariableManager_Create(GSMP_Instance *instance)
 {
+    // TODO How to handle NULL vs nullptr https://devblogs.microsoft.com/oldnewthing/20180307-00/?p=98175
+    // TODO Utility:ErrorNot_NULL/ErrorNot_nullptr
     if (instance != nullptr)
     {
         std::cerr << "[ERROR] Non-null pointer passed to GSMP_VariableManager_Create. Instance already initialized.\n";
@@ -29,16 +31,18 @@ GSMP_API GSMP_VariableManager_Create(GSMP_Instance *instance)
         instance = reinterpret_cast<GSMP_Instance *>(new VariableManager());
     } catch (const std::bad_alloc &)
     {
+        // TODO Utility:ErrorMessage e.g. int ErrorMessage(returnCode, const char*) - which always returns 'ERROR' or a
+        // more specific 'ERROR' code.
         std::cerr << "[ERROR] Memory allocation failed in GSMP_VariableManager_Create.\n";
         return ERROR; // Memory allocation failure
     } catch (const std::exception &ex)
     {
         std::cerr << "[ERROR] Exception caught in GSMP_VariableManager_Create: " << ex.what() << '\n';
-        return ERROR; // Other standard exceptions
+        return ERROR;
     } catch (...)
     {
-        std::cerr << "[INFO] VariableManager instance successfully created.\n";
-        return ERROR; // Catch-all for non-standard exceptions
+        std::cerr << "[ERROR] Failed in GSMP_VariableManager_Create.\n";
+        return ERROR;
     }
 
     return OK;
@@ -55,12 +59,12 @@ GSMP_API GSMP_VariableManager_Destroy(GSMP_Instance *instance)
 
     try
     {
-        std::cerr << "[DEBUG] Deleting VariableManager instance.\n";
         delete reinterpret_cast<VariableManager *>(instance);
-        instance = nullptr; // Set the pointer to null to avoid dangling pointers
+        instance = nullptr; // TODO NULL vs nullptr
     } catch (const std::exception &ex)
     {
-        std::cerr << "[ERROR] Exception caught while deleting instance: " << ex.what() << '\n';
+        std::cerr << "[ERROR] Exception caught in GSMP_VariableManager_Destroy while deleting instance: " << ex.what()
+                  << '\n';
         return ERROR;
     } catch (...)
     {
@@ -73,39 +77,53 @@ GSMP_API GSMP_VariableManager_Destroy(GSMP_Instance *instance)
 }
 
 // Model Variable Instantiation
-// QUESTION - C to CPP types.
-// QUESTION - During Instantiation, we need to copy data when instantiating new instances of objects???
-// QUESTION - When runtime/querying we wish to return current state as reference or as copy ???
-GSMP_API GSMP_VariableManager_AddVariable_Int(GSMP_Instance *instance, const string_t name, int_t *value,
-                                              VariableIntent *intent, string_t description)
+GSMP_API GSMP_VariableManager_AddVariable_Int(GSMP_Instance *instance, const string_t name, const int_t value,
+                                              VariableIntent intent, const string_t description)
 {
     if (instance = nullptr)
     {
-        std::cerr << "[ERROR] Null pointer passed to GSMP_VariableManager_Destroy. Cannot destroy uninitialized "
-                     "instance.\n";
+        std::cerr << "[ERROR] Null pointer passed to GSMP_VariableManager_AddVariable_Int. Cannot destroy "
+                     "uninitialized instance.\n";
         return ERROR; // Instance not initialized
     }
-
-    // TODO Check for invalid arguments: name, intent, value, description.
-    // if ()
-    // {
-    //     std::cerr << "[ERROR] Null name provided to GSMP_VariableManager_AddVariable_Int.\n";
-    //     return ERROR;
-    // }
+    // TODO Check for invalid arguments: name, intent, value, description, or just catch associated exceptions.
 
     try
     {
         // Cast to actual implementation class
         VariableManager *variableManager = reinterpret_cast<VariableManager *>(instance);
 
-        // TODO Cast/Intermediary Types (C to Cpp)
+        // Intermediary Types (C to Cpp)
+        std::string cppName = name;
+        std::string cppDescription = description;
+
+        // ISSUE: GSMP-17 - Require intent to be compatible.
+        ModelVariableIntent cppIntent = ModelVariableIntent::Undefined;
+        switch (intent)
+        {
+            case VariableIntent::INPUT:
+                cppIntent = ModelVariableIntent::Input;
+                break;
+            case VariableIntent::OUTPUT:
+                cppIntent = ModelVariableIntent::Output;
+                break;
+            case VariableIntent::OVERRIDE:
+                cppIntent = ModelVariableIntent::Override;
+                break;
+            default:
+                std::cerr
+                        << "[ERROR] Null pointer passed to GSMP_VariableManager_Destroy. Cannot destroy uninitialized "
+                           "instance.\n";
+                break;
+        }
+        ModelVariableIntent cppIntent = ModelVariableIntent::Input;
 
         // Create Variable
-        // ModelVariable modelVariable = new ModelVariable(name, value, intent, description);
+        // ISSUE: GSMP-17 : Check constructor assignment shallow or deep copy.
+        ModelVariable *modelVariable = new ModelVariable(cppName, value, cppIntent, cppDescription);
 
         // Add Variable to VariableManager instance
-        std::cerr << "[DEBUG] Calling VariableManager::add_variable.\n";
-        ReturnCode returnCode = variableManager->add_variable(modelVariable);
+        variableManager->add_variable(*modelVariable);
 
     } catch (const std::exception &ex)
     {
@@ -120,22 +138,24 @@ GSMP_API GSMP_VariableManager_AddVariable_Int(GSMP_Instance *instance, const str
     std::cerr << "[INFO] GSMP_VariableManager_AddVariable_Int completed successfully.\n";
     return OK;
 }
-GSMP_API GSMP_VariableManager_AddVariable_Single(GSMP_Instance *instance, string_t name, int_t *value,
-                                                 VariableIntent *intent, string_t description);
-GSMP_API GSMP_VariableManager_AddVariable_Double(GSMP_Instance *instance, string_t name, int_t *value,
-                                                 VariableIntent *intent, string_t description);
+GSMP_API GSMP_VariableManager_AddVariable_Single(GSMP_Instance *instance, const string_t name, const single_t value,
+                                                 VariableIntent intent, const string_t description);
+GSMP_API GSMP_VariableManager_AddVariable_Double(GSMP_Instance *instance, const string_t name, const double_t value,
+                                                 VariableIntent intent, const string_t description);
 
 // Model Variables (Runtime)
-GSMP_API GSMP_VariableManager_GetVariableType(GSMP_Instance *instance, string_t name, int_t *value);
+GSMP_API GSMP_VariableManager_GetVariableType(GSMP_Instance *instance, const string_t name, int_t *pValue);
 
-GSMP_API GSMP_VariableManager_GetVariableIntent(GSMP_Instance *instance, string_t name, VariableIntent *variableIntent);
+GSMP_API GSMP_VariableManager_GetVariableIntent(GSMP_Instance *instance, const string_t name,
+                                                VariableIntent *pVariableIntent);
 
-GSMP_API GSMP_VariableManager_GetVariableDescription(GSMP_Instance *instance, string_t name, int_t *value);
+GSMP_API GSMP_VariableManager_GetVariableDescription(GSMP_Instance *instance, const string_t name,
+                                                     string_t *pDescription);
 
-GSMP_API GSMP_VariableManager_SetVariable_Int(GSMP_Instance *instance, string_t name, int_t *value);
-GSMP_API GSMP_VariableManager_SetVariable_Single(GSMP_Instance *instance, string_t name, single_t *value);
-GSMP_API GSMP_VariableManager_SetVariable_Double(GSMP_Instance *instance, string_t name, double_t *value);
+GSMP_API GSMP_VariableManager_SetVariable_Int(GSMP_Instance *instance, const string_t name, int_t *pValue);
+GSMP_API GSMP_VariableManager_SetVariable_Single(GSMP_Instance *instance, const string_t name, single_t *pValue);
+GSMP_API GSMP_VariableManager_SetVariable_Double(GSMP_Instance *instance, const string_t name, double_t *pValue);
 
-GSMP_API GSMP_VariableManager_GetVariable_Int(GSMP_Instance *instance, string_t name, int_t *value);
-GSMP_API GSMP_VariableManager_GetVariable_Single(GSMP_Instance *instance, string_t name, single_t *value);
-GSMP_API GSMP_VariableManager_GetVariable_Double(GSMP_Instance *instance, string_t name, double_t *value);
+GSMP_API GSMP_VariableManager_GetVariable_Int(GSMP_Instance *instance, const string_t name, int_t *pValue);
+GSMP_API GSMP_VariableManager_GetVariable_Single(GSMP_Instance *instance, const string_t name, single_t *pValue);
+GSMP_API GSMP_VariableManager_GetVariable_Double(GSMP_Instance *instance, const string_t name, double_t *pValue);

--- a/src/models/c/src/GSMP_VariableManager_API.cpp
+++ b/src/models/c/src/GSMP_VariableManager_API.cpp
@@ -1,0 +1,141 @@
+/* ────────────────────────────────────────────────────────────────── *
+* FILENAME : GSMP_VariableManager_API.cpp
+*
+* DESCRIPTION : Defines Cpp functions to implement the C API to
+*               CPP Class 'VariableManager'.
+*
+/* ────────────────────────────────────────────────────────────────── */
+
+// C Includes
+#include "GSMP_VariableManager_API.h"
+
+// Cpp Includes
+#include <iostream> // For std::cerr (debug messages)
+#include <new> // For std::nothrow and std::bad_alloc
+#include "variable_manager.h"
+
+
+// Model Instance Management
+GSMP_API GSMP_VariableManager_Create(GSMP_Instance *instance)
+{
+    if (instance != nullptr)
+    {
+        std::cerr << "[ERROR] Non-null pointer passed to GSMP_VariableManager_Create. Instance already initialized.\n";
+        return ERROR; // Instance already initialized
+    }
+
+    try
+    {
+        instance = reinterpret_cast<GSMP_Instance *>(new VariableManager());
+    } catch (const std::bad_alloc &)
+    {
+        std::cerr << "[ERROR] Memory allocation failed in GSMP_VariableManager_Create.\n";
+        return ERROR; // Memory allocation failure
+    } catch (const std::exception &ex)
+    {
+        std::cerr << "[ERROR] Exception caught in GSMP_VariableManager_Create: " << ex.what() << '\n';
+        return ERROR; // Other standard exceptions
+    } catch (...)
+    {
+        std::cerr << "[INFO] VariableManager instance successfully created.\n";
+        return ERROR; // Catch-all for non-standard exceptions
+    }
+
+    return OK;
+};
+
+GSMP_API GSMP_VariableManager_Destroy(GSMP_Instance *instance)
+{
+    if (instance = nullptr)
+    {
+        std::cerr << "[ERROR] Null pointer passed to GSMP_VariableManager_Destroy. Cannot destroy uninitialized "
+                     "instance.\n";
+        return ERROR; // Instance not initialized
+    }
+
+    try
+    {
+        std::cerr << "[DEBUG] Deleting VariableManager instance.\n";
+        delete reinterpret_cast<VariableManager *>(instance);
+        instance = nullptr; // Set the pointer to null to avoid dangling pointers
+    } catch (const std::exception &ex)
+    {
+        std::cerr << "[ERROR] Exception caught while deleting instance: " << ex.what() << '\n';
+        return ERROR;
+    } catch (...)
+    {
+        std::cerr << "[ERROR] Unknown exception caught while deleting instance.\n";
+        return ERROR;
+    }
+
+    std::cerr << "[INFO] VariableManager instance successfully destroyed.\n";
+    return OK;
+}
+
+// Model Variable Instantiation
+// QUESTION - C to CPP types.
+// QUESTION - During Instantiation, we need to copy data when instantiating new instances of objects???
+// QUESTION - When runtime/querying we wish to return current state as reference or as copy ???
+GSMP_API GSMP_VariableManager_AddVariable_Int(GSMP_Instance *instance, const string_t name, int_t *value,
+                                              VariableIntent *intent, string_t description)
+{
+    if (instance = nullptr)
+    {
+        std::cerr << "[ERROR] Null pointer passed to GSMP_VariableManager_Destroy. Cannot destroy uninitialized "
+                     "instance.\n";
+        return ERROR; // Instance not initialized
+    }
+
+    // TODO Check for invalid arguments: name, intent, value, description.
+    // if ()
+    // {
+    //     std::cerr << "[ERROR] Null name provided to GSMP_VariableManager_AddVariable_Int.\n";
+    //     return ERROR;
+    // }
+
+    try
+    {
+        // Cast to actual implementation class
+        VariableManager *variableManager = reinterpret_cast<VariableManager *>(instance);
+
+        // TODO Cast/Intermediary Types (C to Cpp)
+
+        // Create Variable
+        // ModelVariable modelVariable = new ModelVariable(name, value, intent, description);
+
+        // Add Variable to VariableManager instance
+        std::cerr << "[DEBUG] Calling VariableManager::add_variable.\n";
+        ReturnCode returnCode = variableManager->add_variable(modelVariable);
+
+    } catch (const std::exception &ex)
+    {
+        std::cerr << "[ERROR] Exception caught in GSMP_VariableManager_AddVariable_Int: " << ex.what() << '\n';
+        return ERROR;
+    } catch (...)
+    {
+        std::cerr << "[ERROR] Unknown exception caught in GSMP_VariableManager_AddVariable_Int.\n";
+        return ERROR;
+    }
+
+    std::cerr << "[INFO] GSMP_VariableManager_AddVariable_Int completed successfully.\n";
+    return OK;
+}
+GSMP_API GSMP_VariableManager_AddVariable_Single(GSMP_Instance *instance, string_t name, int_t *value,
+                                                 VariableIntent *intent, string_t description);
+GSMP_API GSMP_VariableManager_AddVariable_Double(GSMP_Instance *instance, string_t name, int_t *value,
+                                                 VariableIntent *intent, string_t description);
+
+// Model Variables (Runtime)
+GSMP_API GSMP_VariableManager_GetVariableType(GSMP_Instance *instance, string_t name, int_t *value);
+
+GSMP_API GSMP_VariableManager_GetVariableIntent(GSMP_Instance *instance, string_t name, VariableIntent *variableIntent);
+
+GSMP_API GSMP_VariableManager_GetVariableDescription(GSMP_Instance *instance, string_t name, int_t *value);
+
+GSMP_API GSMP_VariableManager_SetVariable_Int(GSMP_Instance *instance, string_t name, int_t *value);
+GSMP_API GSMP_VariableManager_SetVariable_Single(GSMP_Instance *instance, string_t name, single_t *value);
+GSMP_API GSMP_VariableManager_SetVariable_Double(GSMP_Instance *instance, string_t name, double_t *value);
+
+GSMP_API GSMP_VariableManager_GetVariable_Int(GSMP_Instance *instance, string_t name, int_t *value);
+GSMP_API GSMP_VariableManager_GetVariable_Single(GSMP_Instance *instance, string_t name, single_t *value);
+GSMP_API GSMP_VariableManager_GetVariable_Double(GSMP_Instance *instance, string_t name, double_t *value);


### PR DESCRIPTION
Add common GSMP Enumerations and Types, as C headers for use in C/Cpp source.
Add GSMP_VariableManager header, with function declarations and proposed arguments.
Add GSMP_VariableManager definitions for Create/Destory and Register(Int), as prototype.